### PR TITLE
Integrate IO Control for ros-industrial/motoman

### DIFF
--- a/motoman/motoman_driver/CMakeLists.txt
+++ b/motoman/motoman_driver/CMakeLists.txt
@@ -119,7 +119,8 @@ set_target_properties(motoman_robot_state
 add_executable(motoman_motion_streaming_interface
   src/joint_streaming_node.cpp
   src/joint_trajectory_streamer.cpp
-  src/motion_ctrl.cpp)
+  src/motion_ctrl.cpp
+  src/io_ctrl.cpp)
 target_link_libraries(motoman_motion_streaming_interface
   motoman_simple_message
   motoman_industrial_robot_client
@@ -160,7 +161,8 @@ set_target_properties(motoman_robot_state_bswap
 add_executable(motoman_motion_streaming_interface_bswap
   src/joint_streaming_node.cpp
   src/joint_trajectory_streamer.cpp
-  src/motion_ctrl.cpp)
+  src/motion_ctrl.cpp
+  src/io_ctrl.cpp)
 target_link_libraries(motoman_motion_streaming_interface_bswap
   motoman_simple_message_bswap
   motoman_industrial_robot_client_bswap

--- a/motoman/motoman_driver/include/motoman_driver/io_ctrl.h
+++ b/motoman/motoman_driver/include/motoman_driver/io_ctrl.h
@@ -1,0 +1,101 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2016, Delft Robotics Institute
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of the Delft Robotics Institute, nor the names
+ *    of its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \author G.A. vd. Hoorn (TU Delft Robotics Institute)
+ */
+
+#ifndef MOTOMAN_DRIVER_IO_CTRL_H
+#define MOTOMAN_DRIVER_IO_CTRL_H
+
+#include "simple_message/smpl_msg_connection.h"
+#include "motoman_driver/simple_message/motoman_read_single_io.h"
+#include "motoman_driver/simple_message/motoman_read_single_io_reply.h"
+#include "motoman_driver/simple_message/motoman_write_single_io.h"
+#include "motoman_driver/simple_message/motoman_write_single_io_reply.h"
+
+namespace motoman
+{
+namespace io_ctrl
+{
+using industrial::smpl_msg_connection::SmplMsgConnection;
+using motoman::simple_message::io_ctrl_reply::ReadSingleIOReply;
+using motoman::simple_message::io_ctrl_reply::WriteSingleIOReply;
+
+/**
+ * \brief Wrapper class around Motoman-specific io control commands
+ */
+
+class MotomanIoCtrl
+{
+public:
+  /**
+   * \brief Default constructor
+   */
+  MotomanIoCtrl() {}
+
+  bool init(SmplMsgConnection* connection);
+
+public:
+  /**
+   * \brief Reads a single IO point on the controller.
+   *
+   * Note: if reading was unsuccessful, the value of value is undefined.
+   *
+   * \param address The address (index) of the IO point
+   * \param value [out] Will contain the value of the IO point
+   * \return True IFF reading was successful
+   */
+  bool readSingleIO(industrial::shared_types::shared_int address,
+    industrial::shared_types::shared_int &value);
+
+  /**
+   * \brief Writes to a single IO point on the controller.
+   *
+   * \param address The address (index) of the IO point
+   * \param value The value to set the IO element to
+   * \return True IFF writing was successful
+   */
+  bool writeSingleIO(industrial::shared_types::shared_int address,
+    industrial::shared_types::shared_int value);
+
+protected:
+  SmplMsgConnection* connection_;
+
+  bool sendAndReceive(industrial::shared_types::shared_int address,
+    ReadSingleIOReply &reply);
+  bool sendAndReceive(industrial::shared_types::shared_int address,
+    industrial::shared_types::shared_int value,
+    WriteSingleIOReply &reply);
+};
+
+}  // namespace io_ctrl
+}  // namespace motoman
+
+#endif  // MOTOMAN_DRIVER_IO_CTRL_H

--- a/motoman/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
+++ b/motoman/motoman_driver/include/motoman_driver/joint_trajectory_streamer.h
@@ -41,12 +41,18 @@
 #include "simple_message/simple_message.h"
 #include "std_srvs/Trigger.h"
 
+//Non-Standard Inclusion for IO Control
+#include "motoman_driver/io_ctrl.h"
+#include "motoman_msgs/ReadSingleIO.h"
+#include "motoman_msgs/WriteSingleIO.h"
+
 namespace motoman
 {
 namespace joint_trajectory_streamer
 {
 
 using motoman::motion_ctrl::MotomanMotionCtrl;
+using motoman::io_ctrl::MotomanIoCtrl;
 using industrial_robot_client::joint_trajectory_streamer::JointTrajectoryStreamer;
 using industrial::simple_message::SimpleMessage;
 using industrial::smpl_msg_connection::SmplMsgConnection;
@@ -133,8 +139,17 @@ protected:
 
   int robot_id_;
   MotomanMotionCtrl motion_ctrl_;
+  MotomanIoCtrl io_ctrl_;
 
   std::map<int, MotomanMotionCtrl> motion_ctrl_map_;
+
+  ros::ServiceServer srv_read_single_io;   // handle for read_single_io service
+  ros::ServiceServer srv_write_single_io;   // handle for write_single_io service
+
+  bool readSingleIoCB(motoman_msgs::ReadSingleIO::Request &req,
+                            motoman_msgs::ReadSingleIO::Response &res);
+  bool writeSingleIoCB(motoman_msgs::WriteSingleIO::Request &req,
+                            motoman_msgs::WriteSingleIO::Response &res);
 
   void trajectoryStop();
   bool is_valid(const trajectory_msgs::JointTrajectory &traj);

--- a/motoman/motoman_driver/src/io_ctrl.cpp
+++ b/motoman/motoman_driver/src/io_ctrl.cpp
@@ -1,0 +1,144 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2016, Delft Robotics Institute
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of the Delft Robotics Institute, nor the names
+ *    of its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \author G.A. vd. Hoorn (TU Delft Robotics Institute)
+ */
+
+#include "motoman_driver/io_ctrl.h"
+#include "motoman_driver/simple_message/messages/motoman_read_single_io_message.h"
+#include "motoman_driver/simple_message/messages/motoman_read_single_io_reply_message.h"
+#include "motoman_driver/simple_message/messages/motoman_write_single_io_message.h"
+#include "motoman_driver/simple_message/messages/motoman_write_single_io_reply_message.h"
+#include "ros/ros.h"
+#include "simple_message/simple_message.h"
+#include <string>
+
+
+namespace ReadSingleIOReplyResults = motoman::simple_message::io_ctrl_reply::ReadSingleIOReplyResults;
+namespace WriteSingleIOReplyResults = motoman::simple_message::io_ctrl_reply::WriteSingleIOReplyResults;
+
+using motoman::simple_message::io_ctrl::ReadSingleIO;
+using motoman::simple_message::io_ctrl_message::ReadSingleIOMessage;
+using motoman::simple_message::io_ctrl_reply_message::ReadSingleIOReplyMessage;
+using motoman::simple_message::io_ctrl::WriteSingleIO;
+using motoman::simple_message::io_ctrl_message::WriteSingleIOMessage;
+using motoman::simple_message::io_ctrl_reply_message::WriteSingleIOReplyMessage;
+using industrial::simple_message::SimpleMessage;
+using industrial::shared_types::shared_int;
+
+
+namespace motoman
+{
+namespace io_ctrl
+{
+
+bool MotomanIoCtrl::init(SmplMsgConnection* connection)
+{
+  connection_ = connection;
+  return true;
+}
+
+bool MotomanIoCtrl::readSingleIO(shared_int address, shared_int &value)
+{
+  ReadSingleIOReply reply;
+
+  if (!sendAndReceive(address, reply))
+  {
+    ROS_ERROR("Failed to send READ_SINGLE_IO command");
+    return false;
+  }
+
+  value = reply.getValue();
+
+  return (reply.getResultCode() == ReadSingleIOReplyResults::SUCCESS);
+}
+
+bool MotomanIoCtrl::writeSingleIO(shared_int address, shared_int value)
+{
+  WriteSingleIOReply reply;
+
+  if (!sendAndReceive(address, value, reply))
+  {
+    ROS_ERROR("Failed to send WRITE_SINGLE_IO command");
+    return false;
+  }
+
+  return (reply.getResultCode() == WriteSingleIOReplyResults::SUCCESS);
+}
+
+bool MotomanIoCtrl::sendAndReceive(shared_int address, ReadSingleIOReply &reply)
+{
+  SimpleMessage req, res;
+  ReadSingleIO data;
+  ReadSingleIOMessage read_io_msg;
+  ReadSingleIOReplyMessage read_io_reply;
+
+  data.init(address);
+  read_io_msg.init(data);
+  read_io_msg.toRequest(req);
+
+  if (!this->connection_->sendAndReceiveMsg(req, res))
+  {
+    ROS_ERROR("Failed to send ReadSingleIO message");
+    return false;
+  }
+
+  read_io_reply.init(res);
+  reply.copyFrom(read_io_reply.reply_);
+
+  return true;
+}
+
+bool MotomanIoCtrl::sendAndReceive(shared_int address, shared_int value, WriteSingleIOReply &reply)
+{
+  SimpleMessage req, res;
+  WriteSingleIO data;
+  WriteSingleIOMessage write_io_msg;
+  WriteSingleIOReplyMessage write_io_reply;
+
+  data.init(address, value);
+  write_io_msg.init(data);
+  write_io_msg.toRequest(req);
+
+  if (!this->connection_->sendAndReceiveMsg(req, res))
+  {
+    ROS_ERROR("Failed to send WriteSingleIO message");
+    return false;
+  }
+
+  write_io_reply.init(res);
+  reply.copyFrom(write_io_reply.reply_);
+
+  return true;
+}
+
+} // io_ctrl
+
+} // motoman

--- a/motoman/motoman_driver/src/joint_trajectory_streamer.cpp
+++ b/motoman/motoman_driver/src/joint_trajectory_streamer.cpp
@@ -92,18 +92,6 @@ bool MotomanJointTrajectoryStreamer::init(SmplMsgConnection* connection, const s
 
   enabler_ = node_.advertiseService("robot_enable", &MotomanJointTrajectoryStreamer::enableRobotCB, this);
 
-
-
-  // hacking this in here at this place for IO Control
-  io_ctrl_.init(connection);
-  this->srv_read_single_io = this->node_.advertiseService("read_single_io",
-    &MotomanJointTrajectoryStreamer::readSingleIoCB, this);
-  this->srv_write_single_io = this->node_.advertiseService("write_single_io",
-    &MotomanJointTrajectoryStreamer::writeSingleIoCB, this);
-
-
-
-
   return rtn;
 }
 
@@ -126,6 +114,15 @@ bool MotomanJointTrajectoryStreamer::init(SmplMsgConnection* connection, const s
   disabler_ = node_.advertiseService("robot_disable", &MotomanJointTrajectoryStreamer::disableRobotCB, this);
 
   enabler_ = node_.advertiseService("robot_enable", &MotomanJointTrajectoryStreamer::enableRobotCB, this);
+
+
+  // hacking this in here at this place for IO Control
+  io_ctrl_.init(connection);
+  this->srv_read_single_io = this->node_.advertiseService("read_single_io",
+    &MotomanJointTrajectoryStreamer::readSingleIoCB, this);
+  this->srv_write_single_io = this->node_.advertiseService("write_single_io",
+    &MotomanJointTrajectoryStreamer::writeSingleIoCB, this);
+
 
   return rtn;
 }

--- a/motoman/motoman_msgs/CMakeLists.txt
+++ b/motoman/motoman_msgs/CMakeLists.txt
@@ -25,6 +25,8 @@ add_service_files(
     srv
   FILES
     CmdJointTrajectoryEx.srv
+    ReadSingleIO.srv
+    WriteSingleIO.srv
 )
 
 generate_messages(

--- a/motoman/motoman_msgs/srv/ReadSingleIO.srv
+++ b/motoman/motoman_msgs/srv/ReadSingleIO.srv
@@ -1,0 +1,3 @@
+uint32 address
+---
+int32 value

--- a/motoman/motoman_msgs/srv/WriteSingleIO.srv
+++ b/motoman/motoman_msgs/srv/WriteSingleIO.srv
@@ -1,0 +1,3 @@
+uint32 address
+int32 value
+---


### PR DESCRIPTION
## Overview
Commit initiated by acbuynak for use with MH5 robot + FS100 controller setup AIMS lab. 

## Resources
(based upon commit by gavanderhoorn)
https://github.com/ros-industrial/motoman/compare/kinetic-devel...gavanderhoorn:io_support_rebased

## Related Commits
Commits Included that were already merged with main ros-industrial/motoman branch (kinetic-devel)

[1] driver: add simple message IDs for IO messages
---- https://github.com/ros-industrial/motoman/commit/8255633f364ef2a4c2a0057f2807bd49620c0ff6
---- Notes: 
	As defined in REP-I0004 [1].
	https://github.com/ros-industrial/rep/blob/master/rep-I0004.rst


[2] driver: add simple_message data & msg structures for IO messages.
---- https://github.com/ros-industrial/motoman/commit/a943dcbf06f8fd8d0c9a37ab5677e782fbf492e3
---- Notes: 
	This is the ROS side of the Motoman-specific IO extension to the Simple Message protocol.
	Support for this was added in v1.2.4 of the MotoROS driver (controller side).

